### PR TITLE
Add Playwright Chromium runtime libraries and banner hint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fd-find \
     fzf \
     tree \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
     && apt-get purge -y --auto-remove \
         libssl-dev \
     && rm -rf /var/lib/apt/lists/* \
@@ -171,6 +192,10 @@ echo "   zellij   - Split panes, run Claude, fish, and zsh all at once"
 echo ""
 printf "${GRAY}AI assistant:${NC}\n"
 echo "   claude --dangerously-skip-permissions"
+echo ""
+printf "${GRAY}Browser automation:${NC}\n"
+echo "   Chromium libraries are preinstalled. Fetch the browser with:"
+echo "   npx playwright install chromium"
 echo ""
 
 # Start default shell


### PR DESCRIPTION
- Install the Chromium system libraries (Debian trixie t64 names) so Playwright can run headless Chromium; fixes missing libglib-2.0.so.0
- Add a "Browser automation" section to the startup banner with the npx playwright install chromium command